### PR TITLE
Add SPM_CONFIG_IFS

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ docker run --name spm-client --restart=always -v /var/run/docker.sock:/var/run/d
 
 Parameters:
 - SPM_CONFIG - Multiple App configurations for spm-client-setup-conf.sh separated by ";". 
+- SPM_CONFIG_IFS - A custom config separator in cases where ";" is used as part of a config (like haproxy stats url)
 
 Any Linux command can be executed to modify the configuration using "docker exec -it spm-client your_linux_command" :
 

--- a/run.sh
+++ b/run.sh
@@ -79,7 +79,7 @@ function spm_client_setups ()
 	#Set the field separator to new line
 	IFS_ORIGINAL=$IFS
 	SPM_STANDALONE_MONITOR="disabled"
-	IFS=";"
+	IFS=${SPM_CONFIG_IFS:-";"}
 	if [ -n "$SPM_CONFIG" ]; then
 		for cfg in $SPM_CONFIG
 		do


### PR DESCRIPTION
SPM_CONFIG_IFS is introduced to allow a different SPM_CONFIG separator
in cases where ; is used as part of a service config (like haproxy stats url)

solves #1 